### PR TITLE
fix(cask) remove deprecated conflicts_with formula declarations

### DIFF
--- a/Casks/emacs-app-good.rb
+++ b/Casks/emacs-app-good.rb
@@ -26,25 +26,19 @@ cask 'emacs-app-good' do
     end
   end
 
-  conflicts_with(
-    cask: %w[
-      emacs-app
-      emacs-app-monthly
-      emacs-app-nightly
-      emacs-app-nightly-28
-      emacs-app-nightly-29
-      emacs-app-pretest
-      emacs
-      emacs-nightly
-      emacs-pretest
-      emacs-mac
-      emacs-mac-spacemacs-icon
-    ],
-    formula: %w[
-      emacs
-      emacs-mac
-    ]
-  )
+  conflicts_with cask: %w[
+    emacs-app
+    emacs-app-monthly
+    emacs-app-nightly
+    emacs-app-nightly-28
+    emacs-app-nightly-29
+    emacs-app-pretest
+    emacs
+    emacs-nightly
+    emacs-pretest
+    emacs-mac
+    emacs-mac-spacemacs-icon
+  ]
 
   app 'Emacs.app'
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"

--- a/Casks/emacs-app-monthly.rb
+++ b/Casks/emacs-app-monthly.rb
@@ -30,24 +30,18 @@ cask 'emacs-app-monthly' do
     end
   end
 
-  conflicts_with(
-    cask: %w[
-      emacs-app
-      emacs-app-good
-      emacs-app-nightly-28
-      emacs-app-nightly-29
-      emacs-app-pretest
-      emacs
-      emacs-nightly
-      emacs-pretest
-      emacs-mac
-      emacs-mac-spacemacs-icon
-    ],
-    formula: %w[
-      emacs
-      emacs-mac
-    ]
-  )
+  conflicts_with cask: %w[
+    emacs-app
+    emacs-app-good
+    emacs-app-nightly-28
+    emacs-app-nightly-29
+    emacs-app-pretest
+    emacs
+    emacs-nightly
+    emacs-pretest
+    emacs-mac
+    emacs-mac-spacemacs-icon
+  ]
 
   app 'Emacs.app'
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"

--- a/Casks/emacs-app-nightly-28.rb
+++ b/Casks/emacs-app-nightly-28.rb
@@ -22,25 +22,19 @@ cask 'emacs-app-nightly-28' do
     end
   end
 
-  conflicts_with(
-    cask: %w[
-      emacs-app
-      emacs-app-good
-      emacs-app-monthly
-      emacs-app-nightly
-      emacs-app-nightly-29
-      emacs-app-pretest
-      emacs
-      emacs-nightly
-      emacs-pretest
-      emacs-mac
-      emacs-mac-spacemacs-icon
-    ],
-    formula: %w[
-      emacs
-      emacs-mac
-    ]
-  )
+  conflicts_with cask: %w[
+    emacs-app
+    emacs-app-good
+    emacs-app-monthly
+    emacs-app-nightly
+    emacs-app-nightly-29
+    emacs-app-pretest
+    emacs
+    emacs-nightly
+    emacs-pretest
+    emacs-mac
+    emacs-mac-spacemacs-icon
+  ]
 
   depends_on macos: '>= :big_sur'
 

--- a/Casks/emacs-app-nightly-29.rb
+++ b/Casks/emacs-app-nightly-29.rb
@@ -22,25 +22,19 @@ cask 'emacs-app-nightly-29' do
     end
   end
 
-  conflicts_with(
-    cask: %w[
-      emacs-app
-      emacs-app-good
-      emacs-app-monthly
-      emacs-app-nightly
-      emacs-app-nightly-28
-      emacs-app-pretest
-      emacs
-      emacs-nightly
-      emacs-pretest
-      emacs-mac
-      emacs-mac-spacemacs-icon
-    ],
-    formula: %w[
-      emacs
-      emacs-mac
-    ]
-  )
+  conflicts_with cask: %w[
+    emacs-app
+    emacs-app-good
+    emacs-app-monthly
+    emacs-app-nightly
+    emacs-app-nightly-28
+    emacs-app-pretest
+    emacs
+    emacs-nightly
+    emacs-pretest
+    emacs-mac
+    emacs-mac-spacemacs-icon
+  ]
 
   depends_on macos: '>= :big_sur'
 

--- a/Casks/emacs-app-nightly.rb
+++ b/Casks/emacs-app-nightly.rb
@@ -30,25 +30,19 @@ cask 'emacs-app-nightly' do
     end
   end
 
-  conflicts_with(
-    cask: %w[
-      emacs-app
-      emacs-app-good
-      emacs-app-monthly
-      emacs-app-nightly-28
-      emacs-app-nightly-29
-      emacs-app-pretest
-      emacs
-      emacs-nightly
-      emacs-pretest
-      emacs-mac
-      emacs-mac-spacemacs-icon
-    ],
-    formula: %w[
-      emacs
-      emacs-mac
-    ]
-  )
+  conflicts_with cask: %w[
+    emacs-app
+    emacs-app-good
+    emacs-app-monthly
+    emacs-app-nightly-28
+    emacs-app-nightly-29
+    emacs-app-pretest
+    emacs
+    emacs-nightly
+    emacs-pretest
+    emacs-mac
+    emacs-mac-spacemacs-icon
+  ]
 
   app 'Emacs.app'
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"

--- a/Casks/emacs-app-pretest.rb
+++ b/Casks/emacs-app-pretest.rb
@@ -30,25 +30,19 @@ cask 'emacs-app-pretest' do
     end
   end
 
-  conflicts_with(
-    cask: %w[
-      emacs-app
-      emacs-app-good
-      emacs-app-monthly
-      emacs-app-nightly
-      emacs-app-nightly-28
-      emacs-app-nightly-29
-      emacs
-      emacs-nightly
-      emacs-pretest
-      emacs-mac
-      emacs-mac-spacemacs-icon
-    ],
-    formula: %w[
-      emacs
-      emacs-mac
-    ]
-  )
+  conflicts_with cask: %w[
+    emacs-app
+    emacs-app-good
+    emacs-app-monthly
+    emacs-app-nightly
+    emacs-app-nightly-28
+    emacs-app-nightly-29
+    emacs
+    emacs-nightly
+    emacs-pretest
+    emacs-mac
+    emacs-mac-spacemacs-icon
+  ]
 
   app 'Emacs.app'
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"

--- a/Casks/emacs-app.rb
+++ b/Casks/emacs-app.rb
@@ -30,25 +30,19 @@ cask 'emacs-app' do
     end
   end
 
-  conflicts_with(
-    cask: %w[
-      emacs-app-good
-      emacs-app-monthly
-      emacs-app-nightly
-      emacs-app-nightly-28
-      emacs-app-nightly-29
-      emacs-app-pretest
-      emacs
-      emacs-nightly
-      emacs-pretest
-      emacs-mac
-      emacs-mac-spacemacs-icon
-    ],
-    formula: %w[
-      emacs
-      emacs-mac
-    ]
-  )
+  conflicts_with cask: %w[
+    emacs-app-good
+    emacs-app-monthly
+    emacs-app-nightly
+    emacs-app-nightly-28
+    emacs-app-nightly-29
+    emacs-app-pretest
+    emacs
+    emacs-nightly
+    emacs-pretest
+    emacs-mac
+    emacs-mac-spacemacs-icon
+  ]
 
   app 'Emacs.app'
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"


### PR DESCRIPTION
Fixes #3.

See also https://github.com/Homebrew/brew/pull/20517 and https://github.com/Homebrew/brew/pull/20499.