### PR TITLE
fix: remove deprecated conflicts_with formula parameter

### DIFF
--- a/Casks/emacs-app-pretest.rb
+++ b/Casks/emacs-app-pretest.rb
@@ -30,25 +30,19 @@ cask 'emacs-app-pretest' do
     end
   end
 
-  conflicts_with(
-    cask: %w[
-      emacs-app
-      emacs-app-good
-      emacs-app-monthly
-      emacs-app-nightly
-      emacs-app-nightly-28
-      emacs-app-nightly-29
-      emacs
-      emacs-nightly
-      emacs-pretest
-      emacs-mac
-      emacs-mac-spacemacs-icon
-    ],
-    formula: %w[
-      emacs
-      emacs-mac
-    ]
-  )
+  conflicts_with cask: %w[
+    emacs-app
+    emacs-app-good
+    emacs-app-monthly
+    emacs-app-nightly
+    emacs-app-nightly-28
+    emacs-app-nightly-29
+    emacs
+    emacs-nightly
+    emacs-pretest
+    emacs-mac
+    emacs-mac-spacemacs-icon
+  ]
 
   app 'Emacs.app'
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"


### PR DESCRIPTION
## Summary
- Remove the deprecated `formula:` parameter from `conflicts_with` in `emacs-app-pretest.rb`
- Fixes Homebrew deprecation warnings that appear during `brew update`

## Details
The `conflicts_with formula:` syntax has been deprecated in Homebrew as formula/cask conflicts are now handled automatically. This change removes the deprecated parameter while keeping the cask conflicts intact.

## Test plan
- [x] Verify the cask file syntax is valid
- [x] Confirm deprecation warnings are resolved
- [x] Ensure cask conflicts still work as expected