### PR TITLE
fix(cask): stop using string comparison format

### DIFF
--- a/Casks/emacs-app-good.rb
+++ b/Casks/emacs-app-good.rb
@@ -10,12 +10,12 @@ cask 'emacs-app-good' do
   on_arm do
     sha256 'a1824d28f27b4d738303729dadbb66ede5ca2711ff4a313009061c880a44669e'
     url 'https://github.com/jimeh/emacs-builds/releases/download/Emacs.2025-09-14.897d322.master/Emacs.2025-09-14.897d322.master.macOS-11.arm64.dmg'
-    depends_on macos: '>= :big_sur'
+    depends_on macos: :big_sur
   end
   on_intel do
     sha256 '65947b70a5af300c26e6cbaf7f9cd40fe1e4ee4fc7add60e987ddf1d4fb0a4ac'
     url 'https://github.com/jimeh/emacs-builds/releases/download/Emacs.2025-09-14.897d322.master/Emacs.2025-09-14.897d322.master.macOS-11.x86_64.dmg'
-    depends_on macos: '>= :big_sur'
+    depends_on macos: :big_sur
   end
 
   livecheck do

--- a/Casks/emacs-app-monthly.rb
+++ b/Casks/emacs-app-monthly.rb
@@ -10,12 +10,12 @@ cask 'emacs-app-monthly' do
   on_arm do
     sha256 'd4ddb07c673b8f37ce1c34e4703b3281f527411416ac70255ee84b4c22b01726'
     url 'https://github.com/jimeh/emacs-builds/releases/download/Emacs.2026-05-01.92788f3.master/Emacs.2026-05-01.92788f3.master.macOS-11.arm64.dmg'
-    depends_on macos: '>= :big_sur'
+    depends_on macos: :big_sur
   end
   on_intel do
     sha256 '0f827910d5db7afd3b7aad8789f98c62789a118e99d07b36382f33d2538a23a3'
     url 'https://github.com/jimeh/emacs-builds/releases/download/Emacs.2026-05-01.92788f3.master/Emacs.2026-05-01.92788f3.master.macOS-11.x86_64.dmg'
-    depends_on macos: '>= :big_sur'
+    depends_on macos: :big_sur
   end
 
   livecheck do

--- a/Casks/emacs-app-nightly-28.rb
+++ b/Casks/emacs-app-nightly-28.rb
@@ -38,7 +38,7 @@ cask 'emacs-app-nightly-28' do
     ]
   )
 
-  depends_on macos: '>= :big_sur'
+  depends_on macos: :big_sur
 
   app 'Emacs.app'
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"

--- a/Casks/emacs-app-nightly-29.rb
+++ b/Casks/emacs-app-nightly-29.rb
@@ -38,7 +38,7 @@ cask 'emacs-app-nightly-29' do
     ]
   )
 
-  depends_on macos: '>= :big_sur'
+  depends_on macos: :big_sur
 
   app 'Emacs.app'
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"

--- a/Casks/emacs-app-nightly.rb
+++ b/Casks/emacs-app-nightly.rb
@@ -10,12 +10,12 @@ cask 'emacs-app-nightly' do
   on_arm do
     sha256 '2ec69ef08a70406e8b28e687b451f207369ce8ee04ad0fcefd8d0ee10e06e012'
     url 'https://github.com/jimeh/emacs-builds/releases/download/Emacs.2026-05-18.641754e.master/Emacs.2026-05-18.641754e.master.macOS-11.arm64.dmg'
-    depends_on macos: '>= :big_sur'
+    depends_on macos: :big_sur
   end
   on_intel do
     sha256 'e59af30333485d199d32e5963867f6528c5bd240aaf366e160fb035080fedd2e'
     url 'https://github.com/jimeh/emacs-builds/releases/download/Emacs.2026-05-18.641754e.master/Emacs.2026-05-18.641754e.master.macOS-11.x86_64.dmg'
-    depends_on macos: '>= :big_sur'
+    depends_on macos: :big_sur
   end
 
   livecheck do

--- a/Casks/emacs-app-pretest.rb
+++ b/Casks/emacs-app-pretest.rb
@@ -10,12 +10,12 @@ cask 'emacs-app-pretest' do
   on_arm do
     sha256 '7b83465eb5fd9cd9cecf3d318d154516ba0481e67957ddcc8669f43c53e80c53'
     url 'https://github.com/jimeh/emacs-builds/releases/download/Emacs-30.1.90-pretest/Emacs.2025-05-18.1136aed.emacs-30-1-90-pretest.macOS-11.arm64.dmg'
-    depends_on macos: '>= :big_sur'
+    depends_on macos: :big_sur
   end
   on_intel do
     sha256 'e19f10777998947cd0267ea435345945c75660033e0885f7bd5b1666e0fb8f59'
     url 'https://github.com/jimeh/emacs-builds/releases/download/Emacs-30.1.90-pretest/Emacs.2025-05-18.1136aed.emacs-30-1-90-pretest.macOS-11.x86_64.dmg'
-    depends_on macos: '>= :big_sur'
+    depends_on macos: :big_sur
   end
 
   livecheck do

--- a/Casks/emacs-app.rb
+++ b/Casks/emacs-app.rb
@@ -10,12 +10,12 @@ cask 'emacs-app' do
   on_arm do
     sha256 '8277021ed3eb716333120638ffc2565c1b893e9146e06738bb3521630f39eb19'
     url 'https://github.com/jimeh/emacs-builds/releases/download/Emacs-30.2-1/Emacs.2025-08-14.636f166.emacs-30-2-1.macOS-11.arm64.dmg'
-    depends_on macos: '>= :big_sur'
+    depends_on macos: :big_sur
   end
   on_intel do
     sha256 '9eade73998b1772fb8fba74cfa02ca25ab06285287a6b2bccafc14f609860f8c'
     url 'https://github.com/jimeh/emacs-builds/releases/download/Emacs-30.2-1/Emacs.2025-08-14.636f166.emacs-30-2-1.macOS-11.x86_64.dmg'
-    depends_on macos: '>= :big_sur'
+    depends_on macos: :big_sur
   end
 
   livecheck do

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -7,14 +7,14 @@
   on_arm do
     sha256 '{{ $arm64SHA }}'
     url '{{ $arm64URL }}'
-    depends_on macos: '>= :big_sur'
+    depends_on macos: :big_sur
   end
 {{- end }}
 {{- if ne $x86_64URL "" }}
   on_intel do
     sha256 '{{ $x86_64SHA }}'
     url '{{ $x86_64URL }}'
-    depends_on macos: '>= :big_sur'
+    depends_on macos: :big_sur
   end
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
Deprecated:

```
$ brew update
==> Updating Homebrew...
Already up-to-date.
Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :big_sur` instead.
Please report this issue to the jimeh/homebrew-emacs-builds tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/jimeh/homebrew-emacs-builds/Casks/emacs-app.rb:13
```