### PR TITLE
fix(cask): stop using string comparison format

### DIFF
--- a/Casks/emacs-app-good.rb
+++ b/Casks/emacs-app-good.rb
@@ -10,12 +10,12 @@ cask 'emacs-app-good' do
   on_arm do
     sha256 'a1824d28f27b4d738303729dadbb66ede5ca2711ff4a313009061c880a44669e'
     url 'https://github.com/jimeh/emacs-builds/releases/download/Emacs.2025-09-14.897d322.master/Emacs.2025-09-14.897d322.master.macOS-11.arm64.dmg'
-    depends_on macos: '>= :big_sur'
+    depends_on macos: :big_sur
   end
   on_intel do
     sha256 '65947b70a5af300c26e6cbaf7f9cd40fe1e4ee4fc7add60e987ddf1d4fb0a4ac'
     url 'https://github.com/jimeh/emacs-builds/releases/download/Emacs.2025-09-14.897d322.master/Emacs.2025-09-14.897d322.master.macOS-11.x86_64.dmg'
-    depends_on macos: '>= :big_sur'
+    depends_on macos: :big_sur
   end
 
   livecheck do

--- a/Casks/emacs-app-monthly.rb
+++ b/Casks/emacs-app-monthly.rb
@@ -10,12 +10,12 @@ cask 'emacs-app-monthly' do
   on_arm do
     sha256 '88a33765877303559ab628b16690d2f2d17afcf3249908dc7cf3e93d4f781fb5'
     url 'https://github.com/jimeh/emacs-builds/releases/download/Emacs.2026-07-01.398a8c7.master/Emacs.2026-07-01.398a8c7.master.macOS-11.arm64.dmg'
-    depends_on macos: '>= :big_sur'
+    depends_on macos: :big_sur
   end
   on_intel do
     sha256 '23cc1d4fd8f2689ada622953ad652d93b6f8124ec065052113926d0e7e12732e'
     url 'https://github.com/jimeh/emacs-builds/releases/download/Emacs.2026-07-01.398a8c7.master/Emacs.2026-07-01.398a8c7.master.macOS-11.x86_64.dmg'
-    depends_on macos: '>= :big_sur'
+    depends_on macos: :big_sur
   end
 
   livecheck do

--- a/Casks/emacs-app-nightly-28.rb
+++ b/Casks/emacs-app-nightly-28.rb
@@ -38,7 +38,7 @@ cask 'emacs-app-nightly-28' do
     ]
   )
 
-  depends_on macos: '>= :big_sur'
+  depends_on macos: :big_sur
 
   app 'Emacs.app'
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"

--- a/Casks/emacs-app-nightly-29.rb
+++ b/Casks/emacs-app-nightly-29.rb
@@ -38,7 +38,7 @@ cask 'emacs-app-nightly-29' do
     ]
   )
 
-  depends_on macos: '>= :big_sur'
+  depends_on macos: :big_sur
 
   app 'Emacs.app'
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"

--- a/Casks/emacs-app-nightly.rb
+++ b/Casks/emacs-app-nightly.rb
@@ -10,12 +10,12 @@ cask 'emacs-app-nightly' do
   on_arm do
     sha256 '0f946ed755a3103dcaace4d4eb7bdcfe8ec1748fb4dfdc3b73d2b45804b0025b'
     url 'https://github.com/jimeh/emacs-builds/releases/download/Emacs.2026-07-07.202d297.master/Emacs.2026-07-07.202d297.master.macOS-11.arm64.dmg'
-    depends_on macos: '>= :big_sur'
+    depends_on macos: :big_sur
   end
   on_intel do
     sha256 'db821a6387520c5555a384e762e22c8be73cd7db7c7d9b5634e458a5e89d1d2e'
     url 'https://github.com/jimeh/emacs-builds/releases/download/Emacs.2026-07-07.202d297.master/Emacs.2026-07-07.202d297.master.macOS-11.x86_64.dmg'
-    depends_on macos: '>= :big_sur'
+    depends_on macos: :big_sur
   end
 
   livecheck do

--- a/Casks/emacs-app-pretest.rb
+++ b/Casks/emacs-app-pretest.rb
@@ -10,12 +10,12 @@ cask 'emacs-app-pretest' do
   on_arm do
     sha256 'eb1ff19221a5cadbccc23354bd665ce1049518569db8dc53fc2b08ee2f9db4ab'
     url 'https://github.com/jimeh/emacs-builds/releases/download/Emacs-31.0.90-pretest/Emacs.2026-06-05.0ee48ac.emacs-31-0-90-pretest.macOS-11.arm64.dmg'
-    depends_on macos: '>= :big_sur'
+    depends_on macos: :big_sur
   end
   on_intel do
     sha256 '05bb80e0aaffee8cb1b9630a947424533ddb2530c81922eb5b06588ac1a5c093'
     url 'https://github.com/jimeh/emacs-builds/releases/download/Emacs-31.0.90-pretest/Emacs.2026-06-05.0ee48ac.emacs-31-0-90-pretest.macOS-11.x86_64.dmg'
-    depends_on macos: '>= :big_sur'
+    depends_on macos: :big_sur
   end
 
   livecheck do

--- a/Casks/emacs-app.rb
+++ b/Casks/emacs-app.rb
@@ -10,12 +10,12 @@ cask 'emacs-app' do
   on_arm do
     sha256 '8277021ed3eb716333120638ffc2565c1b893e9146e06738bb3521630f39eb19'
     url 'https://github.com/jimeh/emacs-builds/releases/download/Emacs-30.2-1/Emacs.2025-08-14.636f166.emacs-30-2-1.macOS-11.arm64.dmg'
-    depends_on macos: '>= :big_sur'
+    depends_on macos: :big_sur
   end
   on_intel do
     sha256 '9eade73998b1772fb8fba74cfa02ca25ab06285287a6b2bccafc14f609860f8c'
     url 'https://github.com/jimeh/emacs-builds/releases/download/Emacs-30.2-1/Emacs.2025-08-14.636f166.emacs-30-2-1.macOS-11.x86_64.dmg'
-    depends_on macos: '>= :big_sur'
+    depends_on macos: :big_sur
   end
 
   livecheck do

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -7,14 +7,14 @@
   on_arm do
     sha256 '{{ $arm64SHA }}'
     url '{{ $arm64URL }}'
-    depends_on macos: '>= :big_sur'
+    depends_on macos: :big_sur
   end
 {{- end }}
 {{- if ne $x86_64URL "" }}
   on_intel do
     sha256 '{{ $x86_64SHA }}'
     url '{{ $x86_64URL }}'
-    depends_on macos: '>= :big_sur'
+    depends_on macos: :big_sur
   end
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
Homebrew warns that string comparison syntax for macOS dependencies is deprecated. This reapplies #8 on top of current `main` so the fix can merge cleanly while retaining the newer cask versions.

The generated casks now use the supported symbol form, and the shared template is updated so future generated casks keep that syntax. The original contributor is preserved as the commit author.

## Testing

- Ruby syntax checks pass for all seven changed casks.
- `git diff --check` passes.
